### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/obus.opam
+++ b/obus.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "menhir" {build}
   "xmlm"
   "lwt" {>= "2.7.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.