### PR TITLE
Upgrades needed for Lwt.5.0.0 (and ppxlib-related fixes)

### DIFF
--- a/obus.opam
+++ b/obus.opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.1"}
   "menhir" {build}
   "xmlm"
-  "lwt" {>= "2.7.0"}
+  "lwt" {>= "5.0.0"}
   "lwt_ppx"
   "lwt_log"
   "lwt_react"

--- a/obus.opam
+++ b/obus.opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.1"}
   "menhir" {build}
   "xmlm"
-  "lwt" {>= "5.0.0"}
+  "lwt" {>= "4.3.0"}
   "lwt_ppx"
   "lwt_log"
   "lwt_react"

--- a/src/protocol/oBus_wire.ml
+++ b/src/protocol/oBus_wire.ml
@@ -865,8 +865,10 @@ let write_message_with_fds writer ?byte_order msg =
           (* Ensures there is nothing left to send: *)
           let%lwt () = Lwt_io.flush oc in
           let len = String.length buf in
+          let vec = Lwt_unix.IO_vectors.create () in
+          Lwt_unix.IO_vectors.append_bytes vec (Bytes.unsafe_of_string buf) 0 len;
           (* Send the file descriptors and the message: *)
-          let%lwt n = Lwt_unix.send_msg writer.w_file_descr [Lwt_unix.io_vector buf 0 len] (Array.to_list fds) in
+          let%lwt n = Lwt_unix.send_msg writer.w_file_descr vec (Array.to_list fds) in
           assert (n >= 0 && n <= len);
           (* Write what is remaining: *)
           Lwt_io.write_from_string_exactly oc buf n (len - n)

--- a/src/protocol/oBus_wire.ml
+++ b/src/protocol/oBus_wire.ml
@@ -868,7 +868,7 @@ let write_message_with_fds writer ?byte_order msg =
           let vec = Lwt_unix.IO_vectors.create () in
           Lwt_unix.IO_vectors.append_bytes vec (Bytes.unsafe_of_string buf) 0 len;
           (* Send the file descriptors and the message: *)
-          let%lwt n = Lwt_unix.send_msg writer.w_file_descr vec (Array.to_list fds) in
+          let%lwt n = Lwt_unix.Versioned.send_msg_2 writer.w_file_descr vec (Array.to_list fds) in
           assert (n >= 0 && n <= len);
           (* Write what is remaining: *)
           Lwt_io.write_from_string_exactly oc buf n (len - n)


### PR DESCRIPTION
This one is related to https://github.com/ocsigen/lwt/issues/594

Unfortunately this breaks compatibility with Lwt<5.0.0, so I had to upgrade version constraints.

@aantron Is there any way to support both pre-lwt.5.0.0 and lwt.5.0.0 io_vectors in a maintainable way?