### PR TITLE
Port ppx from omp to ppxlib

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.1)
+(lang dune 1.4)
 (using menhir 2.0)

--- a/obus.opam
+++ b/obus.opam
@@ -21,6 +21,5 @@ depends: [
   "lwt_ppx"
   "lwt_log"
   "lwt_react"
-  "ocaml-migrate-parsetree"
   "ppxlib"
 ]

--- a/src/ppx/dune
+++ b/src/ppx/dune
@@ -3,5 +3,5 @@
  (public_name obus.ppx)
  (kind ppx_rewriter)
  (synopsis "Utility syntax for defining D-Bus errors")
- (libraries ocaml-migrate-parsetree)
+ (libraries ppxlib)
  (preprocess (pps ppxlib.metaquot)))


### PR DESCRIPTION
This PR ports `obus.ppx` from OMP to ppxlib. As discussed [here](https://discuss.ocaml.org/t/ocaml-migrate-parsetree-2-0-0/5991/2), the next major release of OMP will drop significant parts of its API including the driver and Ast_mapper.

I did the naive port using `Ast_traverse` to keep this simple but I have the feeling this could be turned into a deriving ppx.
Maybe with a few changes to ppxlib we wouldn't even have to break the ppx's API and could keep the `[@@obus ...]` syntax. Rewriting as such would improve performances when `obus.ppx` is combined with other PPXes.

You'll note that I bumped the minimum requirement for dune. That is due to the fact the 2.0 menhir extension is only available from dune 1.4 forward.