### PR TITLE
Some fixes to obus client generation

### DIFF
--- a/tools/tools_util/utils.ml
+++ b/tools/tools_util/utils.ml
@@ -130,7 +130,7 @@ let convertor_recv top typ =
     (fun top t ->
        match t with
          | "int32" | "uint32" -> Some "Int32.to_int"
-         | "object_path" -> Some(paren top ("OBus_proxy.make (OBus_context.sender context)"))
+         | "object_path" -> Some(paren top ("(fun x -> OBus_proxy.make ~peer:(OBus_context.sender context) ~path:x)"))
          | name when List.mem name dbus_symbols -> None
          | name -> Some("make_" ^ name))
     top typ

--- a/tools/transformers/obus_gen_client.ml
+++ b/tools/transformers/obus_gen_client.ml
@@ -141,7 +141,7 @@ let print_impl oc name members symbols annotations =
              output_string oc "         ";
              print_names oc names;
              output_string oc ")\n";
-             fprintf oc "      (OBus_signal.connect s_%s proxy)\n" name
+             fprintf oc "      (OBus_signal.make s_%s proxy)\n" name
            end
        | Property(name, typ, access, annotations) ->
            fprintf oc "\n  let %s proxy =\n" (OBus_name.ocaml_lid name);


### PR DESCRIPTION
 - Fix compilation error when generating signals.
 - Use keyword arguments when calling `OBus_proxy.make`, fixing several compilation warnings.