### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/obus.opam
+++ b/obus.opam
@@ -21,5 +21,5 @@ depends: [
   "lwt_ppx"
   "lwt_log"
   "lwt_react"
-  "ppxlib"
+  "ppxlib" {>= "0.26.0"}
 ]

--- a/src/ppx/ppx_obus.ml
+++ b/src/ppx/ppx_obus.ml
@@ -42,7 +42,7 @@ let register_obus_exception = function
               in ()
           ] in
       (match exn.ptyexn_constructor.pext_kind with
-      | Pext_decl (Pcstr_tuple [typ], None) ->
+      | Pext_decl (_, Pcstr_tuple [typ], None) ->
           Some (registerer typ)
       | _ ->
         Location.raise_errorf ~loc:pstr_loc


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.