### PR TITLE
Add support for OCaml 5.0

### DIFF
--- a/obus.opam
+++ b/obus.opam
@@ -1,19 +1,19 @@
 opam-version: "2.0"
 
-name: "obus"
 synopsis: "Pure Ocaml implementation of the D-Bus protocol"
 maintainer: "freyrnjordrson@gmail.com"
 authors: [ "Jérémie Dimino" ]
 homepage: "https://github.com/ocaml-community/obus"
 bug-reports: "https://github.com/ocaml-community/obus/issues"
 dev-repo: "git+https://github.com/ocaml-community/obus.git"
-license: "BSD3"
+license: "BSD-3-Clause"
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 depends: [
+  "ocaml" {>= "4.07"}
   "dune" {>= "1.1"}
   "menhir" {build}
   "xmlm"

--- a/src/internals/oBus_path.ml
+++ b/src/internals/oBus_path.ml
@@ -14,7 +14,7 @@ open OBus_string
 type element = string
 type t = element list
 
-let compare = Pervasives.compare
+let compare = Stdlib.compare
 
 let is_valid_char ch =
   (ch >= 'A' && ch <= 'Z') ||

--- a/src/internals/oBus_path.mli
+++ b/src/internals/oBus_path.mli
@@ -16,7 +16,7 @@ type t = element list
     (** A complete path *)
 
 val compare : t -> t -> int
-  (** Same as [Pervasives.compare]. It allows this module to be used
+  (** Same as [Stdlib.compare]. It allows this module to be used
       as argument to the functors [Set.Make] and [Map.Make]. *)
 
 (** {6 Construction} *)

--- a/src/protocol/oBus_connection.ml
+++ b/src/protocol/oBus_connection.ml
@@ -131,7 +131,7 @@ and t = <
   (* Signal holding the current connection state. *)
 >
 
-let compare : t -> t -> int = Pervasives.compare
+let compare : t -> t -> int = Stdlib.compare
 
 (* +-----------------------------------------------------------------+
    | Guids                                                           |
@@ -140,7 +140,7 @@ let compare : t -> t -> int = Pervasives.compare
 (* Mapping from server guid to connection. *)
 module Guid_map = Map.Make(struct
                             type t = OBus_address.guid
-                            let compare = Pervasives.compare
+                            let compare = Stdlib.compare
                           end)
 
 let guid_connection_map = ref Guid_map.empty

--- a/src/protocol/oBus_connection.mli
+++ b/src/protocol/oBus_connection.mli
@@ -18,7 +18,7 @@ type t
     (** Type of D-Bus connections *)
 
 val compare : t -> t -> int
-  (** Same as [Pervasives.compare]. It allows this module to be used
+  (** Same as [Stdlib.compare]. It allows this module to be used
       as argument to the functors [Set.Make] and [Map.Make]. *)
 
 (** {6 Creation} *)

--- a/src/protocol/oBus_peer.ml
+++ b/src/protocol/oBus_peer.ml
@@ -14,7 +14,7 @@ type t = {
   name : OBus_name.bus;
 }
 
-let compare = Pervasives.compare
+let compare = Stdlib.compare
 
 let connection p = p.connection
 let name p = p.name

--- a/src/protocol/oBus_peer.mli
+++ b/src/protocol/oBus_peer.mli
@@ -24,7 +24,7 @@ type t = {
 }
 
 val compare : t -> t -> int
-  (** Same as [Pervasives.compare]. It allows this module to be used
+  (** Same as [Stdlib.compare]. It allows this module to be used
       as argument to the functors [Set.Make] and [Map.Make]. *)
 
 val connection : t -> OBus_connection.t

--- a/src/protocol/oBus_property.ml
+++ b/src/protocol/oBus_property.ml
@@ -62,7 +62,7 @@ module Group_map = Map.Make
             - name of the owner of the property
             - path of the object owning the property
             - interfaec of the property *)
-     let compare = Pervasives.compare
+     let compare = Stdlib.compare
    end)
 
 (* Type of a cache for a group *)

--- a/src/protocol/oBus_proxy.ml
+++ b/src/protocol/oBus_proxy.ml
@@ -17,7 +17,7 @@ type t = {
   path : OBus_path.t;
 }
 
-let compare = Pervasives.compare
+let compare = Stdlib.compare
 
 let make ~peer ~path = { peer = peer; path = path }
 

--- a/src/protocol/oBus_proxy.mli
+++ b/src/protocol/oBus_proxy.mli
@@ -22,7 +22,7 @@ type t = {
 }
 
 val compare : t -> t -> int
-  (** Same as [Pervasives.compare]. It allows this module to be used
+  (** Same as [Stdlib.compare]. It allows this module to be used
       as argument to the functors [Set.Make] and [Map.Make]. *)
 
 val make : peer : OBus_peer.t -> path : OBus_path.t -> t

--- a/src/protocol/oBus_signal.ml
+++ b/src/protocol/oBus_signal.ml
@@ -119,7 +119,7 @@ let with_match_rule match_rule sd =
 module Signal_map = Map.Make
   (struct
      type t = OBus_path.t option * OBus_name.interface * OBus_name.member
-     let compare = Pervasives.compare
+     let compare = Stdlib.compare
    end)
 
 type info = {

--- a/src/protocol/oBus_wire.ml
+++ b/src/protocol/oBus_wire.ml
@@ -510,7 +510,7 @@ end
    | Common writing functions                                      |
    +---------------------------------------------------------------+ *)
 
-module FD_map = Map.Make(struct type t = Unix.file_descr let compare = Pervasives.compare end)
+module FD_map = Map.Make(struct type t = Unix.file_descr let compare = Stdlib.compare end)
 
 (* A pointer for serializing data *)
 type wpointer = {

--- a/tools/introspection/obus_introspect.ml
+++ b/tools/introspection/obus_introspect.ml
@@ -65,7 +65,7 @@ let main service path =
   begin
     match !obj_mode with
       | false ->
-          OBus_introspect.output (Xmlm.make_output ~nl:true ~indent:(Some 2) (`Channel Pervasives.stdout))
+          OBus_introspect.output (Xmlm.make_output ~nl:true ~indent:(Some 2) (`Channel Stdlib.stdout))
             (Interface_map.fold (fun name (content, annots) acc -> (name, content, annots) :: acc) map [], [])
       | true ->
           List.iter begin fun (proxy, interfaces) ->


### PR DESCRIPTION
If you don't care about supporting OCaml < 4.08 you can simply drop 6f118835ccd233fa0d25964370499f21ef6676c9